### PR TITLE
Updated Eclipse 3.7 download link in Getting Started guide

### DIFF
--- a/user/gettingstarted.rst
+++ b/user/gettingstarted.rst
@@ -97,7 +97,7 @@ Check the :ref:`faq_known-issues` section.
 .. _current section: http://scala-ide.org/download/current.html
 .. _eclipsify: https://github.com/musk/SbtEclipsify/tree/0.8.0
 .. _Eclipse 3.6 (Helios): http://www.eclipse.org/downloads/packages/release/helios/sr2
-.. _Eclipse 3.7 (Indigo): http://www.eclipse.org/downloads/
+.. _Eclipse 3.7 (Indigo): http://www.eclipse.org/downloads/packages/eclipse-classic-372/indigosr2
 .. _m2eclipse: http://www.eclipse.org/m2e/
 .. _m2eclipse-scala: https://github.com/sonatype/m2eclipse-scala
 .. _maven: http://maven.apache.org/


### PR DESCRIPTION
The reason is that now, when you go to the Eclipse downloads link that's currently in place (http://www.eclipse.org/downloads), Eclipse 4.2 Juno is the Eclipse version listed under "Eclipse Classic"

It takes a bit of clicking around to once again find the page for Eclipse 3.7. So, I suggest linking people here, instead: http://www.eclipse.org/downloads/packages/eclipse-classic-372/indigosr2
