### PR TITLE
Added missing step to setup guide for Scala 2.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ To setup Sphinx locally, use ``easy_install``:
     $ sudo easy_install "sphinx==1.1.2"
     $ sudo easy_install pygments # required on some systems
 
-Then simply use ``make clean html`` from the repository root to generate the files.
+Then simply use ``sbt make-site`` from the repository root to generate the files.
 
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _Sphinx: http://sphinx.pocoo.org/

--- a/src/sphinx/dev/setup/setup.rst
+++ b/src/sphinx/dev/setup/setup.rst
@@ -101,7 +101,9 @@ Now click the "Order and Export" tab and make sure to export all JARs click the 
    :target: ../../_images/order-export.png
  
  
-Click OK. 
+Click OK.
+
+Additionally, if you're using scala 2.10, you need to right-click the 2.9 folder in the ``org.scala-ide.sdt.core`` project and select ``Build Path -> Remove from Build Path`` and add the 2.10 folder instead by right-clicking and selecting ``Build Path -> Use as Source Folder``.
  
 If after rebuilding you see any errors, drop us a note in the `Scala IDE Developer 
 Mailing List <http://groups.google.com/group/scala-ide-dev?pli=1>`_.


### PR DESCRIPTION
The guide didn't mention that in addition to updating the jars you also need to
have the right scala folder (2.9, 2.10, 2.11) on the build path. This fixes assembla
ticket #1001320.
