### PR TITLE
Added a link to the presentation compiler document

### DIFF
--- a/src/sphinx/dev/architecture/architecture.rst
+++ b/src/sphinx/dev/architecture/architecture.rst
@@ -118,9 +118,7 @@ The Scala Presentation Compiler
 -------------------------------
 
 In order to provide semantic actions, the IDE needs to *understand* the edited Scala code. That 
-means parsing and type-checking. The `Scala Presentation Compiler 
-<https://github.com/scala-ide/scala-ide/blob/master/org.scala-ide.sdt.core/src/scala/tools/eclipse/ScalaPresentationCompiler.scala>`_ 
-is an asynchronous front-end compiler for Scala, part of the standard Scala compiler.
+means parsing and type-checking. :ref:`scalapresentationcompiler` is an asynchronous front-end compiler for Scala, part of the standard Scala compiler.
 
 Code formatting
 ---------------

--- a/src/sphinx/dev/architecture/presentation-compiler.rst
+++ b/src/sphinx/dev/architecture/presentation-compiler.rst
@@ -1,3 +1,6 @@
+
+.. _scalapresentationcompiler:
+
 The Scala Presentation Compiler
 ===============================
 


### PR DESCRIPTION
Previously the section about the PC in the architecture document
linked to the source of the PC. I changed it such that it links
to the document we now have the describes the PC.
