### PR TITLE
Update src/sphinx/tutorials/play20scalaide20/index.rst

### DIFF
--- a/src/sphinx/tutorials/play20scalaide20/index.rst
+++ b/src/sphinx/tutorials/play20scalaide20/index.rst
@@ -90,7 +90,7 @@ Play 2.0-RC1 integrates `sbteclipse`_, which allow to create configuration files
        :width: 100%
        :target: ../../_images/play20-scalaide20-06.png
 
-*   ``eclipsify`` is the command to invoke sbteclipse in Play.
+*   ``eclipsify`` is the command to invoke sbteclipse in Play. (In Play 2.1, the command is ``eclipse``)
 
     .. image:: images/play20-scalaide20-09.png
        :alt: eclipse


### PR DESCRIPTION
Now, in Play 2.1, `eclipsify` is called `eclipse`

https://groups.google.com/forum/?fromgroups=#!topic/play-framework/eQs5tHQqZBM
