### PR TITLE
Fix bug in AndroidDevelopment guide

### DIFF
--- a/src/sphinx/tutorials/androiddevelopment/index.rst
+++ b/src/sphinx/tutorials/androiddevelopment/index.rst
@@ -29,7 +29,7 @@ Step 2: Enable Scala and AndroidProguardScala
 (???)
 
 #. Open an Android project.
-#. Right-click the project and choose Add Scala Nature (may be under the Scala sub-menu).
+#. Right-click the project and choose Add Scala Nature (which may be under the 'Configure' sub-menu).
 #. After a successful build, right-click the project and choose Add AndroidProguardScala Nature.
 
 Step 3: Develop for Android using Scala


### PR DESCRIPTION
To apply a Scala Nature, the 'Configure' sub-menu must be used.
Adding the nature creates the 'Scala' sub-menu (which can then be used
to remove the Nature)
