### PR TITLE
Updated note on how to run partest

### DIFF
--- a/src/sphinx/dev/testing/presentation-compiler-tests.rst
+++ b/src/sphinx/dev/testing/presentation-compiler-tests.rst
@@ -129,12 +129,11 @@ the future. The currently available markers are:
 
 Each of them is very easy to use. Just look at the other tests if you have any doubt.
 
-Now, we can try running the test. Again in the opened terminal, go under ``<project-root>/test`` 
-and type
+Now, we can try running the test. Again in the opened terminal type:
 
 .. code-block:: bash
 
-	$ ./partest files/presentation/ide-bug-1000475
+	$ ./test/partest test/files/presentation/ide-bug-1000475
 
 You should see something like
 


### PR DESCRIPTION
It appears that something in the `partest` config has changed since the guide was written. If you invoke `partest` from inside of the `test` folder you will get the following complaints:

``` bash
Buildfile: build.xml does not exist!
Build failed
cat: /Users/hartmann/dev/scala/test/build/pack/partest.properties: No such file or directory
Error: Could not find or load main class scala.tools.partest.nest.ConsoleRunner
```

If you run in from the root then everything works as you'd expect.
