### PR TITLE
Documentation for new expression evaluator

### DIFF
--- a/src/sphinx/dev/architecture/architecture.rst
+++ b/src/sphinx/dev/architecture/architecture.rst
@@ -117,6 +117,8 @@ Scala IDE debugger
 
 The Scala IDE debugger is using the standard Java debugging chain (JVMDI, JDWP and JDI) to provide a Scala specific debugger. The elements are displayed the Scala way, the names are decoded, and the actions are behaving the way a Scala developer would expect.
 
+See also :ref:`expression-evaluator`.
+
 The Scala Structure Builder
 ---------------------------
 
@@ -161,7 +163,7 @@ for syntax coloring are also backed by Scalariform.
 
 
 Refactoring
-------------
+-----------
 
 Refactoring is delegated to the `scala-refactoring <http://scala-refactoring.org/>`_ library written 
 by Mirko Stocker.

--- a/src/sphinx/dev/architecture/expression-evaluator.rst
+++ b/src/sphinx/dev/architecture/expression-evaluator.rst
@@ -2,12 +2,14 @@
    are made available under the terms of the Scala License which accompanies this distribution, and
    is available at http://www.scala-lang.org/node/146
 
-.. _expression-evaluator:
+.. include:: /global_defs.hrst
 
-Expression evaluator
-====================
+Expression evaluator |new|
+==========================
 
 Scala debugger uses new expression evaluator, which translates user code into invocations of ``JDI`` remote calls. This allows evaluation of expression in context of some breakpoint, with access to local variables and methods.
+
+.. _expression-evaluator:
 
 Expression evaluation
 ---------------------

--- a/src/sphinx/dev/architecture/expression-evaluator.rst
+++ b/src/sphinx/dev/architecture/expression-evaluator.rst
@@ -1,0 +1,82 @@
+.. Copyright (c) 2014 Contributor. All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Scala License which accompanies this distribution, and
+   is available at http://www.scala-lang.org/node/146
+
+.. _expression-evaluator:
+
+Expression evaluator
+====================
+
+Scala debugger uses new expression evaluator, which translates user code into invocations of ``JDI`` remote calls. This allows evaluation of expression in context of some breakpoint, with access to local variables and methods.
+
+Expression evaluation
+---------------------
+
+Overview
+~~~~~~~~
+
+Main entry point into expression evaluation in Scala IDE debugger is ``ExpressionManager`` object, which is initialized from ``ScalaDebugger`` during debug and takes care of holding debug session state, and evaluating expressions in GUI friendly way.
+
+Expression evaluation is done in ``ExpressionEvaluator`` which parses the code using ``ToolBox``, applies several transformations to it and then compiles the result with ``ToolBox``.
+
+Transformation phases
+~~~~~~~~~~~~~~~~~~~~~
+
+Before evaluation multiple AST transformations (called ``phases``) are performed.
+
+First few of them are necessary to make user-defined code type-check:
+
+* code is packed into function from :ref:`expression-evaluator_jdi-context` to :ref:`expression-evaluator_jdi-proxy`,
+* unbound variables are mocked,
+* usages of ``this`` are mocked,
+* and lamba bodies are replaced with stubs of correct types.
+
+Next comes type-check (from ``ToolBox``), which expands implicits, assign types and make some other Scala magic.
+
+After type-check code is transformed further to allow remote execution:
+
+* all used variables and objects are implemented using :ref:`expression-evaluator_jdi-proxy`,
+* constructor calls are proxied to create new instances on debugged jvm,
+* bodies of lambdas are compiled and bytecode is loaded on debugged jvn,
+* conditional expressions are changed to work with proxies,
+* same with toString invocations,
+* literals and constants are proxied,
+* and all mocks from earlier stages are replaced with concrete implementation.
+
+After that code is compiled and result is a function ``JdiContext => JdiProxy``.
+
+Each phase have access to ``TypesContext``, which is mutable, append-only structure which stores information about types encountered during transformation for further processing.
+
+.. _expression-evaluator_jdi-proxy:
+
+JdiProxy
+~~~~~~~~
+
+Every unbound variable used in evaluated expression is replaced with instance of ``JdiProxy``. Those proxies uses ``scala.Dynamic`` trait to intercept all method calls and proxy them to debugged jvm.
+
+Because of synthetic methods on primitive types, boxed types and ``java.lang.String`` we had to create a separate proxy flavors for each of them.
+
+* Numeric addition, subtraction, multiplication, division and modulo are aggregated under ``NumericOperations``.
+* Bitwise OR, AND and XOR are aggregated under ``BitwiseOperations``.
+* Comparison (<, >, <= and >=) is implemented in ``BooleanComparison`` and ``NumericComparison``.
+* Logical operations (for Boolean proxies) are implemented in ``LogicalOperations``.
+
+All above sits in package ``org.scalaide.debug.internal.expression.proxies.primitives``.
+
+.. _expression-evaluator_jdi-context:
+
+JdiContext
+~~~~~~~~~~
+
+All methods related to debugged jvm are encapsulated within a ``JdiContext`` instance. It provides abilities to:
+
+* run methods on debugged jvm,
+* access types and values in context of debugged jvm,
+* load new classes on debugged jvm,
+* create proxies for values and object by name,
+* and create String representations of proxies.
+
+Conditional breakpoints
+-----------------------
+
+Support for conditional breakpoint is placed in ``ConditionManager`` and relies on ``ExpressionManager`` to do all heavy lifting.

--- a/src/sphinx/dev/index.rst
+++ b/src/sphinx/dev/index.rst
@@ -18,6 +18,7 @@ Contents:
    building/building
    architecture/architecture
    architecture/presentation-compiler
+   architecture/expression-evaluator
    code/code
    testing/testing
    repository-organization/repository-organization


### PR DESCRIPTION
Documentation for new expression evaluator (https://github.com/scala-ide/scala-ide/pull/684).
 
Disclaimer required by the lawyers:
 
THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.