### PR TITLE
Fix errors while generating docs. Probably the fact that we have the sam...

### DIFF
--- a/src/sphinx/3.0.x/faq/known-issues.rst
+++ b/src/sphinx/3.0.x/faq/known-issues.rst
@@ -30,7 +30,7 @@ The code contains Unicode niceties like ``←`` and ``⇒``, but the editor does
 
 The operating system is not using UTF-8 by default, and its default encoding is used inside Eclipse.
 
-The encoding used to open files can be configured at different levels. Most of the time, setting Eclipse default encoding to UTF-8 in ``General → Workspace`` in the preferences [#preferences]_ is enough. But in some case, the wrong encoding might also have been set in the project properties, or even the file properties.
+The encoding used to open files can be configured at different levels. Most of the time, setting Eclipse default encoding to UTF-8 in ``General → Workspace`` preferences is enough. But in some case, the wrong encoding might also have been set in the project properties, or even the file properties.
 
 Red screen of death (red squiggles everywhere)
 ...............................................
@@ -150,5 +150,3 @@ If you have several update sites providing different version of Scala IDE, Eclip
 .. _#1000996: http://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1000996
 
 .. _m2eclipse-scala: https://github.com/sonatype/m2eclipse-scala
-
-.. [#preferences] The Eclipse preferences are accessible using ``Windows → Preferences`` (or ``Eclipse → Preferences`` on Mac osX).

--- a/src/sphinx/changelog.rst
+++ b/src/sphinx/changelog.rst
@@ -63,7 +63,7 @@ RC1 (unreleased)
  - Moves content of core.api in core, and adds Ixxx prefix
  - Faster implementation of `ScalaCommentScanner` (:ticket:`1002241`)
  - Shut up noisy logger. (:ticket:`1002228`)
- - Add *.tmpBin files to .gitignore
+ - Add `*.tmpBin` files to .gitignore
  - Mark some completion tests as flaky.
  - Creates an API for ScalaPlugin
  - Fix Luna build by using the AJDT dev version of the weaving hook.


### PR DESCRIPTION
...e

footnote reference in several places (current-docs/2.0.x-docs and the like)
was the problem.
