### PR TITLE
Adding missing dependency to build file

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,8 @@ resolvers += "sonatype-releases" at "https://oss.sonatype.org/service/local/repo
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
+
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.2")


### PR DESCRIPTION
If one does not have this dependency in global sbt settings, sbt fails to load with strange error:

```
C:\Users\Jerzy\Workspaces\GitHub\scala-ide-docs>sbt
(...)
[error] java.lang.NoClassDefFoundError: org/eclipse/jgit/storage/file/FileRepository
[error] Use 'last' for the full log.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? r
```
